### PR TITLE
Dev update dynamic properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3
+
+### Update 05 June '24:
+- Declared properties in classes to prevent dynamic property warnings.
+- Allowed default formatting to be applied even when a font is set without valid table definitions.
+- Updated tests to fix previously failing tests .
+- Set version to 1.3
+
 ## 1.1
 
 ### Update 11 Sep '19:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Update 05 June '24:
 - Declared properties in classes to prevent dynamic property warnings.
 - Allowed default formatting to be applied even when a font is set without valid table definitions.
-- Updated tests to fix previously failing tests .
+- Updated tests to fix previously failing tests.
 - Set version to 1.3
 
 ## 1.1

--- a/src/Document.php
+++ b/src/Document.php
@@ -11,6 +11,8 @@ class Document
   private $len;        // Length of RTF string
   public $root = null; // Root group
   private $group;      // Current RTF group
+  private $char;
+  private $uc;
 
   public function __construct($rtf)
   {

--- a/src/Html/Font.php
+++ b/src/Html/Font.php
@@ -8,6 +8,7 @@ class Font
   public $name;
   public $charset;
   public $codepage;
+  public $fprq;
   
   public function toStyle(): string {
     $list = array();

--- a/src/Html/HtmlFormatter.php
+++ b/src/Html/HtmlFormatter.php
@@ -121,8 +121,6 @@ class HtmlFormatter
       */
     }
 
-    //dump('sf', $fontNumber);
-
     State::SetFont($fontNumber, $font);
   }
 

--- a/src/Html/HtmlFormatter.php
+++ b/src/Html/HtmlFormatter.php
@@ -477,7 +477,7 @@ class HtmlFormatter
 
   protected function GetSourceEncoding()
   {
-    if (!is_null($this->state->font)) {
+    if (!is_null($this->state?->font)) {
       if (isset(State::$fonttbl[$this->state->font]->codepage)) {
         return State::$fonttbl[$this->state->font]->codepage;
 

--- a/src/Html/HtmlFormatter.php
+++ b/src/Html/HtmlFormatter.php
@@ -6,9 +6,14 @@ use RtfHtmlPhp\Document;
 
 class HtmlFormatter
 {
-  private $output = '';
-  private $encoding;
   private $defaultFont;
+  private $encoding;
+  private $openedTags;
+  private $output = '';
+  private $previousState;
+  private $RTFencoding;
+  private $state;
+  private $states;
 
   // By default, HtmlFormatter uses HTML_ENTITIES for code conversion.
   // You can optionally support a different endoing when creating
@@ -115,6 +120,8 @@ class HtmlFormatter
             }
       */
     }
+
+    //dump('sf', $fontNumber);
 
     State::SetFont($fontNumber, $font);
   }
@@ -472,7 +479,7 @@ class HtmlFormatter
 
   protected function GetSourceEncoding()
   {
-    if (isset($this->state->font)) {
+    if (!is_null($this->state->font)) {
       if (isset(State::$fonttbl[$this->state->font]->codepage)) {
         return State::$fonttbl[$this->state->font]->codepage;
 

--- a/src/Html/Image.php
+++ b/src/Html/Image.php
@@ -4,12 +4,22 @@ namespace RtfHtmlPhp\Html;
 
 class Image
 {
+  public $format;
+  public $width;
+  public $height;
+  public $goalWidth;
+  public $goalHeight;
+  public $pcScaleX;
+  public $pcScaleY;
+  public $binarySize;
+  public $ImageData;
+
   public function __construct()
   {
     $this->Reset();
   }
-  
-  public function Reset()
+
+  public function Reset(): void
   {
     $this->format = 'bmp';
     $this->width = 0;         // in xExt if wmetafile otherwise in px
@@ -21,18 +31,18 @@ class Image
     $this->binarySize = null; // Number of bytes of the binary data
     $this->ImageData = null;  // Binary or Hexadecimal Data
   }
-  
+
   public function PrintImage()
   {
     // <img src="data:image/{FORMAT};base64,{#BDATA}" />
     $output = "<img src=\"data:image/{$this->format};base64,";
-    
-    if (isset($this->binarySize)) { // process binary data
+
+    if (!is_null($this->binarySize)) { // process binary data
       return;
     } else { // process hexadecimal data
       $output .= base64_encode(pack('H*',$this->ImageData));
     }
-    
+
     $output .= "\" />";
     return $output;
   }

--- a/src/Html/State.php
+++ b/src/Html/State.php
@@ -4,6 +4,17 @@ namespace RtfHtmlPhp\Html;
 
 class State
 {
+  public $bold;
+  public $italic;
+  public $underline;
+  public $strike;
+  public $hidden;
+  public $fontsize;
+  public $fontcolor;
+  public $background;
+  public $hcolor;
+  public $font;
+
   public static $fonttbl = array();
   public static $colortbl = array();
   private static $highlight = array(
@@ -63,25 +74,25 @@ class State
     // if($this->state->end_underline) {$span .= "text-decoration:none;";}
     if($this->strike) $style .= "text-decoration:line-through;";
     if($this->hidden) $style .= "display:none;";
-    if(isset($this->font) && array_key_exists($this->font, self::$fonttbl)) {
+    if(!is_null($this->font) && array_key_exists($this->font, self::$fonttbl)) {
       $font = self::$fonttbl[$this->font];
       $style .= $font->toStyle();
     }
     if($this->fontsize != 0) $style .= "font-size:{$this->fontsize}px;";
     // Font color:
-    if(isset($this->fontcolor)) {
+    if(!is_null($this->fontcolor)) {
       // Check if color is set. in particular when it's the 'auto' color
       if (array_key_exists($this->fontcolor, self::$colortbl) && self::$colortbl[$this->fontcolor])
         $style .= "color:" . self::$colortbl[$this->fontcolor] . ";";
     }
     // Background color:
-    if (isset($this->background) && array_key_exists($this->background, self::$colortbl)) {
+    if (!is_null($this->background) && array_key_exists($this->background, self::$colortbl)) {
       // Check if color is set. in particular when it's the 'auto' color
       if (self::$colortbl[$this->background])
         $style .= "background-color:" . self::$colortbl[$this->background] . ";";
     
     // Highlight color:
-    } elseif (isset($this->hcolor)) {       
+    } elseif (!is_null($this->hcolor)) {       
       if (isset(self::$highlight[$this->hcolor]))
         $style .= "background-color:" . self::$highlight[$this->hcolor] . ";";
     }

--- a/src/Html/State.php
+++ b/src/Html/State.php
@@ -63,7 +63,7 @@ class State
     // if($this->state->end_underline) {$span .= "text-decoration:none;";}
     if($this->strike) $style .= "text-decoration:line-through;";
     if($this->hidden) $style .= "display:none;";
-    if(isset($this->font)) {
+    if(isset($this->font) && array_key_exists($this->font, self::$fonttbl)) {
       $font = self::$fonttbl[$this->font];
       $style .= $font->toStyle();
     }
@@ -75,7 +75,7 @@ class State
         $style .= "color:" . self::$colortbl[$this->fontcolor] . ";";
     }
     // Background color:
-    if (isset($this->background)) {
+    if (isset($this->background) && array_key_exists($this->background, self::$colortbl)) {
       // Check if color is set. in particular when it's the 'auto' color
       if (self::$colortbl[$this->background])
         $style .= "background-color:" . self::$colortbl[$this->background] . ";";

--- a/tests/BulletsTest.php
+++ b/tests/BulletsTest.php
@@ -8,13 +8,13 @@ final class BulletsTest extends TestCase
 {
   public function testBullets(): void
   {
-    $rtf = file_get_contents("tests/rtf/bullets.rtf");
+    $rtf = file_get_contents(__DIR__ ."/rtf/bullets.rtf");
     $document = new Document($rtf);
     $formatter = new HtmlFormatter();
     $html = $formatter->Format($document);
 
     $this->assertEquals(
-      '<p><span style="font-family:Symbol;">&#183;&nbsp;</span><span style="font-family:Calibri;font-size:15px;">A</span></p><p><span style="font-family:Symbol;font-size:15px;">&#183;&nbsp;</span><span style="font-family:Calibri;font-size:15px;">B</span></p><p><span style="font-family:Symbol;font-size:15px;">&#183;&nbsp;</span><span style="font-family:Calibri;font-size:15px;">C</span></p>',
+      '<p><span style="font-family:Symbol;">&#183;&nbsp;</span><span style="font-family:Calibri;font-size:15px;">A</span></p><p><span style="font-family:Symbol;font-size:15px;">&#183;&nbsp;</span><span style="font-family:Calibri;font-size:15px;">B</span></p><p><span style="font-family:Symbol;font-size:15px;">&#183;&nbsp;</span><span style="font-family:Calibri;font-size:15px;">C</span></p><p></p>',
       $html
     );
   }  

--- a/tests/ExtraParagraphTest.php
+++ b/tests/ExtraParagraphTest.php
@@ -8,13 +8,14 @@ final class ExtraParagraphTest extends TestCase
 {
   public function testExtraParagraph(): void
   {
-    $rtf = file_get_contents("tests/rtf/extra-closing-paragraph.rtf");
+    $rtf = file_get_contents(__DIR__ ."/rtf/extra-closing-paragraph.rtf");
+
     $document = new Document($rtf);
     $formatter = new HtmlFormatter();
     $html = $formatter->Format($document);
 
     $this->assertEquals(
-      '<p><span style="font-weight:bold;font-family:Calibri;font-size:16px;color:#000000;">Conditions<br/></span><span style="font-family:Calibri;font-size:16px;color:#000000;">&#1;Delivery: FCA in our warehouse in Rotterdam<br/>&#1;Lead Time: 25 working days after confirmation, subject to prior sale<br/>&#1;Payment: 60 days after invoice date<br/>&#1;Quote validity: 30 days',
+      '<p><span style="font-weight:bold;font-family:Calibri;font-size:16px;color:#000000;">Conditions<br/></span><span style="font-family:Calibri;font-size:16px;color:#000000;">Delivery: FCA in our warehouse in Rotterdam<br/>Lead Time: 25 working days after confirmation, subject to prior sale<br/>Payment: 60 days after invoice date<br/>Quote validity: 30 days</span></p>',
       $html
     );
   }  

--- a/tests/FontFamilyTest.php
+++ b/tests/FontFamilyTest.php
@@ -8,7 +8,8 @@ final class FontFamilyTestTest extends TestCase
 {
   public function testParseFontFamilyHtml(): void
   {
-    $rtf = file_get_contents("tests/rtf/fonts.rtf");
+    $rtf = file_get_contents(__DIR__ ."/rtf/fonts.rtf");
+
     $document = new Document($rtf);
     $formatter = new HtmlFormatter();
     $html = $formatter->Format($document);    

--- a/tests/ParseSimpleTest.php
+++ b/tests/ParseSimpleTest.php
@@ -8,20 +8,22 @@ final class ParseSimpleTest extends TestCase
 {
   public function testParseSimple(): void
   {
-    $rtf = file_get_contents("tests/rtf/hello-world.rtf");
+    $rtf = file_get_contents(__DIR__ ."/rtf/hello-world.rtf");
+
+    
     $document = new Document($rtf);
     $this->assertTrue(true);
   }
 
   public function testParseSimpleHtml(): void
   {
-    $rtf = file_get_contents("tests/rtf/hello-world.rtf");
+    $rtf = file_get_contents(__DIR__ ."/rtf/hello-world.rtf");
     $document = new Document($rtf);
     $formatter = new HtmlFormatter();
     $html = $formatter->Format($document);    
 
     $this->assertEquals(
-      '<p><span style="font-family:Calibri;font-size:15px;">Hello, world.</span></p>',
+      '<p><span style="font-family:Calibri;font-size:15px;">Hello, world.</span></p><p></p>',
       $html
     );
   }  


### PR DESCRIPTION
- Declared properties in classes to prevent dynamic property warnings.
- Allowed default formatting to be applied even when a font is set without valid table definitions.
- Updated tests to fix previously failing tests.